### PR TITLE
New variable to specify the AWS profile to use

### DIFF
--- a/bootcamp.tf
+++ b/bootcamp.tf
@@ -85,10 +85,14 @@ variable "client-instance-type" {
   default = "t3a.large"
 }
 
+variable "aws-profile" {
+  default = "default"
+}
+
 // Provider
 
 provider "aws" {
-  profile    = "default"
+  profile    = var.aws-profile
   region     = var.region
 }
 

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -3,6 +3,7 @@ owner-email = "sven@confluent.io"
 owner-name = "sven"
 key-name = "sven-ireland-sa"
 purpose = "bootcamp-prep"
+aws-profile = "default"
 
 # Do not touch these
 region = "eu-west-1"


### PR DESCRIPTION
From the bootcamp... we can specify the AWS profile to use, in our cases it was 492737776546-ConfluentSAAdminRole