### PR TITLE
Add shared services for Kafka Connect Advanced bootcamp

### DIFF
--- a/bootcamp-europe.tfvars
+++ b/bootcamp-europe.tfvars
@@ -16,6 +16,7 @@ schema-count = 2
 rest-count = 1
 ksql-count = 2
 c3-count = 1
+elastic-count = 3
 
 vpc-security-group-ids = ["sg-055c8c07419910751"]
 vpc-id = "vpc-08da1069e2646f90f"
@@ -29,4 +30,4 @@ rest-instance-type = "t3.medium"
 c3-instance-type = "t3a.large"
 ksql-instance-type = "t3a.large"
 client-instance-type = "t3.medium"
-
+elastic-instance-type = "t3a.2xlarge"

--- a/bootcamp-us.tfvars
+++ b/bootcamp-us.tfvars
@@ -23,6 +23,7 @@ schema-count = 2
 rest-count = 1
 ksql-count = 2
 c3-count = 1
+elastic-count = 3
 
 zk-instance-type = "t3a.large"
 broker-instance-type = "t3a.large"
@@ -32,3 +33,4 @@ rest-instance-type = "t3.medium"
 c3-instance-type = "t3a.large"
 ksql-instance-type = "t3a.large"
 client-instance-type = "t3.medium"
+elastic-instance-type = "t3a.2xlarge"

--- a/bootcamp.tf
+++ b/bootcamp.tf
@@ -395,6 +395,45 @@ resource "aws_route53_record" "ksql" {
   records = ["${element(aws_instance.ksql.*.private_ip, count.index)}"]
 }
 
+
+resource "aws_instance" "elastic" {
+  count         = var.elastic-count
+  ami           = var.aws-ami-id
+  instance_type = var.elastic-instance-type
+  availability_zone = var.availability-zone
+  key_name = var.key-name
+
+  root_block_device {
+    volume_size = 1000 # 1TB
+  }
+
+  tags = {
+    Name = "${var.owner-name}-elastic-${count.index}-${var.availability-zone}"
+    description = "Elasticsearch nodes - Managed by Terraform"
+    role = "schema"
+    Owner_Name = var.owner-name
+    Owner_Email = var.owner-email
+    purpose = var.purpose
+    sshUser = var.linux-user
+    region = var.region
+    role_region = "schema-${var.region}"
+  }
+
+  subnet_id = var.subnet-id
+  vpc_security_group_ids = var.vpc-security-group-ids
+  associate_public_ip_address = true
+}
+
+resource "aws_route53_record" "elastic" {
+  count = var.elastic-count
+  zone_id = var.hosted-zone-id
+  name = "elastic-${count.index}.${var.owner-name}"
+  type = "A"
+  ttl = "300"
+  records = ["${element(aws_instance.ksql.*.private_ip, count.index)}"]
+}
+
+
 // Output
 
 output "zookeeper_private_dns" {

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -20,6 +20,8 @@ schema-count = 2
 rest-count = 1
 ksql-count = 2
 c3-count = 1
+elastic-count = 3
+
 
 vpc-security-group-ids = ["sg-055c8c07419910751"]
 vpc-id = "vpc-08da1069e2646f90f"
@@ -33,6 +35,6 @@ rest-instance-type = "t3a.large"
 c3-instance-type = "r5.2xlarge"
 ksql-instance-type = "t3a.large"
 client-instance-type = "t3a.large"
+elastic-instance-type = "t3a.2xlarge"
 
 hosted-zone-id = "Z062492024YHYM5K442Z8"
-


### PR DESCRIPTION
This PR adds shared resources for the Kafka Connect Advanced Bootcamp. 

These are the resources added:

* 3 EC2 instances in order to deploy a custom Elassticsearch + Kibana
* 1 RDS (Managed) Oracle 12 DB (single region)
* 1 RDS (Managed) Mysql 5.7 DB (single region)


Hopefully I have not missed anything, please let me know how it looks for you. Happy to do any improvement necessary.